### PR TITLE
Cam 2104 avs cvv result

### DIFF
--- a/opp/facade.py
+++ b/opp/facade.py
@@ -465,14 +465,17 @@ class AsynchronousPayments(object):
 
 
 class Result(object):
-    def __init__(self, code=None, description=None):
+    def __init__(self, code=None, description=None, avs_response=None, cvv_response=None):
         self.code = code
         self.description = description
+        self.avs_response = avs_response
+        self.cvv_response = cvv_response
 
     @staticmethod
     def from_params(params):
         if params is not None:
-            return Result(code=params.get('code'), description=params.get('description'))
+            return Result(code=params.get('code'), description=params.get('description'),
+                avs_response=params.get('avsResponse') , cvv_response=params.get('cvvResponse'))
 
 
 class Merchant(object):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 setup(
     name='opp',
-    version='1.2.0',
+    version='1.2.1',
     description='Python wrapper for OPP',
     author='PAY.ON',
     author_email='opp@payon.com',
@@ -30,5 +30,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=install_requires,
-    download_url='https://github.com/OpenPaymentPlatform/python/tarball/1.2.0'
+    download_url='https://github.com/OpenPaymentPlatform/python/tarball/1.2.1'
 )

--- a/tests/facade/test_from_params.py
+++ b/tests/facade/test_from_params.py
@@ -172,11 +172,15 @@ class TestFromParams(unittest.TestCase):
     def test_result_from_params(self):
         result_with_result_parameters = opp.facade.Result.from_params(
             {"code": "000.100.110",
-             "description": "Request successfully processed"
+             "description": "Request successfully processed",
+             "avsResponse": "Y",
+             "cvvResponse": "M",
              }
         )
         self.assertEqual(result_with_result_parameters.code, "000.100.110")
         self.assertEqual(result_with_result_parameters.description, "Request successfully processed")
+        self.assertEqual(result_with_result_parameters.avs_response, "Y")
+        self.assertEqual(result_with_result_parameters.cvv_response, "M")
 
     def test_merchant_from_params(self):
         bank_account_parameters = {"bankAccount": {"holder": "Jane Jones",


### PR DESCRIPTION
This updates the Result object to capture the avs and cvv response that may be optionally provided in the result section of the raw response.

I've bumped the point version from 1.2.0 to 1.2.1.