### PR TITLE
save the registration ID on the response object if provided

### DIFF
--- a/opp/facade.py
+++ b/opp/facade.py
@@ -530,7 +530,7 @@ class ResponseParameters(object):
     def __init__(self, id=None, payment_type=None, payment_brand=None, amount=None, currency=None, descriptor=None,
                  result=None, card_account=None, virtual_account=None, bank_account=None, customer=None,
                  billing_address=None, shipping_address=None, cart=None, merchant=None, redirect=None,
-                 timestamp=None, build_number=None, ndc=None, result_details=None):
+                 timestamp=None, build_number=None, ndc=None, result_details=None, registration_id=None):
         self.id = id
         self.payment_type = payment_type
         self.payment_brand = payment_brand
@@ -551,6 +551,7 @@ class ResponseParameters(object):
         self.build_number = build_number
         self.ndc = ndc
         self.result_details = result_details
+        self.registration_id = registration_id
 
     @staticmethod
     def from_params(params):
@@ -580,6 +581,7 @@ class ResponseParameters(object):
             build_number = params.get('buildNumber')
             ndc = params.get('ndc')
             result_details = params.get('resultDetails')
+            registration_id = params.get('registrationId')
             response_params = ResponseParameters(id=id, payment_type=payment_type, payment_brand=payment_brand,
                                                  amount=amount, currency=currency, descriptor=descriptor,
                                                  result=result, card_account=card_account,
@@ -587,7 +589,8 @@ class ResponseParameters(object):
                                                  bank_account=bank_account, customer=customer,
                                                  billing_address=billing_address, shipping_address=shipping_address,
                                                  cart=cart, merchant=merchant, redirect=redirect, timestamp=timestamp,
-                                                 build_number=build_number, ndc=ndc, result_details=result_details)
+                                                 build_number=build_number, ndc=ndc, result_details=result_details,
+                                                 registration_id=registration_id)
 
             return response_params
 

--- a/tests/facade/test_from_params.py
+++ b/tests/facade/test_from_params.py
@@ -346,7 +346,8 @@ class TestFromParams(unittest.TestCase):
                                    "ConnectorTxID2": "614486",
                                    "ConnectorTxID3": "827428|||74301731986",
                                    "clearingInstituteName": "Some Institute",
-                               }
+                               },
+                               "registrationId": "8a82944a5dbc8820015dc30fc19e3641"
                                }
         response = opp.facade.ResponseParameters.from_params(response_parameters)
         self.assertEqual(response.id, "8a8294494e735cfa014e763863a80add")
@@ -421,3 +422,4 @@ class TestFromParams(unittest.TestCase):
         self.assertEqual(response.result_details["ConnectorTxID2"], "614486")
         self.assertEqual(response.result_details["ConnectorTxID3"], "827428|||74301731986")
         self.assertEqual(response.result_details["clearingInstituteName"], "Some Institute")
+        self.assertEqual(response.registration_id, "8a82944a5dbc8820015dc30fc19e3641")


### PR DESCRIPTION
This saves the registration id on the response object if its provided in the raw response.