### PR TITLE
Allow custom params to be sent with a Reversal request

### DIFF
--- a/opp/facade.py
+++ b/opp/facade.py
@@ -659,8 +659,10 @@ class Reversals(object):
         self.core = core
         self.reversals = core.payments(payment_id=payment_id)
 
-    def create(self):
-        response = self.reversals.create(**{"paymentType": "RV"})
+    def create(self, custom_parameters=None):
+        request = merge_inputs_to_dict(custom_parameters)
+        request['paymentType'] = "RV"
+        response = self.reversals.create(**request)
         ErrorUtils.raise_exception_for_error_code(self.core.http_client.response.status_code, response)
         return opp.facade.ResponseParameters.from_params(response)
 

--- a/opp/facade.py
+++ b/opp/facade.py
@@ -474,8 +474,10 @@ class Result(object):
     @staticmethod
     def from_params(params):
         if params is not None:
-            return Result(code=params.get('code'), description=params.get('description'),
-                avs_response=params.get('avsResponse') , cvv_response=params.get('cvvResponse'))
+            return Result(
+                code=params.get('code'), description=params.get('description'),
+                avs_response=params.get('avsResponse'), cvv_response=params.get('cvvResponse')
+            )
 
 
 class Merchant(object):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 
 setup(
     name='opp',
-    version='1.2.1',
+    version='1.3.0',
     description='Python wrapper for OPP',
     author='PAY.ON',
     author_email='opp@payon.com',
@@ -30,5 +30,5 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=install_requires,
-    download_url='https://github.com/OpenPaymentPlatform/python/tarball/1.2.1'
+    download_url='https://github.com/OpenPaymentPlatform/python/tarball/1.3.0'
 )


### PR DESCRIPTION
This updates the Reversal request to allow for custom params to be sent.  Also I fixed some indentation that was not great.

The version is bumped to 1.3.0, as this is new non-breaking functionality.